### PR TITLE
Allow custom organization name for config profiles

### DIFF
--- a/cmd/micromdm/serve.go
+++ b/cmd/micromdm/serve.go
@@ -84,6 +84,7 @@ func serve(args []string) error {
 		flCommandWebhookURL      = flagset.String("command-webhook-url", env.String("MICROMDM_WEBHOOK_URL", ""), "URL to send command responses")
 		flHomePage               = flagset.Bool("homepage", env.Bool("MICROMDM_HTTP_HOMEPAGE", true), "Hosts a simple built-in webpage at the / address")
 		flSCEPClientValidity     = flagset.Int("scep-client-validity", env.Int("MICROMDM_SCEP_CLIENT_VALIDITY", 365), "Sets the scep certificate validity in days")
+		flSCEPOrg                = flagset.String("scep-organization", env.String("MICROMDM_SCEP_ORGANIZATION", "MicroMDM"), "Set organization name in configuration profiles")
 		flNoCmdHistory           = flagset.Bool("no-command-history", env.Bool("MICROMDM_NO_COMMAND_HISTORY", false), "disables saving of command history")
 		flUseDynChallenge        = flagset.Bool("use-dynamic-challenge", env.Bool("MICROMDM_USE_DYNAMIC_CHALLENGE", false), "require dynamic SCEP challenges")
 		flGenDynChalEnroll       = flagset.Bool("gen-dynamic-challenge", env.Bool("MICROMDM_GEN_DYNAMIC_CHALLENGE", false), "generate dynamic SCEP challenges in enrollment profile (built-in only)")
@@ -131,6 +132,7 @@ func serve(args []string) error {
 		ServerPublicURL:        strings.TrimRight(*flServerURL, "/"),
 		Depsim:                 *flDepSim,
 		TLSCertPath:            *flTLSCert,
+		SCEPOrg:                *flSCEPOrg,
 		CommandWebhookURL:      *flCommandWebhookURL,
 		NoCmdHistory:           *flNoCmdHistory,
 		UseDynSCEPChallenge:    *flUseDynChallenge,

--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,5 @@ require (
 replace github.com/fullsailor/pkcs7 => github.com/groob/pkcs7 v0.0.0-20180824154052-36585635cb64
 
 go 1.13
+
+replace github.com/micromdm/scep => github.com/imperosoftware/scep v1.0.1-0.20210420100517-1e6a90e736d0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/groob/pkcs7 v0.0.0-20180824154052-36585635cb64 h1:1ALD84dEnUxPKZENhUA
 github.com/groob/pkcs7 v0.0.0-20180824154052-36585635cb64/go.mod h1:mEOMQ8C7oeXY3LnE2jy4UkLAqrW9rrpwiP5U4hVV+MY=
 github.com/groob/plist v0.0.0-20180203051248-dd56909aee38 h1:afbUddvIjPRC7XHHgeSTRfzZtIxEsSl4VCxumLBGDJU=
 github.com/groob/plist v0.0.0-20180203051248-dd56909aee38/go.mod h1:qg2Nek0ND/hIr+nY8H1oVqEW2cLzVVNaAQ0QexOyjyc=
+github.com/imperosoftware/scep v1.0.1-0.20210420100517-1e6a90e736d0 h1:ti6fSAvjxO/oDEU6SaveLFoTMfwKScfdN4vU4zL49/c=
+github.com/imperosoftware/scep v1.0.1-0.20210420100517-1e6a90e736d0/go.mod h1:a4hGfYA9e51888COzEduLGsstH9NPxJPndn/Ke5/Tw8=
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0 h1:5B0uxl2lzNRVkJVg+uGHxWtRt4C0Wjc6kJKo5XYx8xE=
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/mdm/enroll/service_test.go
+++ b/mdm/enroll/service_test.go
@@ -1,0 +1,41 @@
+package enroll
+
+import (
+	"testing"
+)
+
+func TestEscapeAttributeValue(t *testing.T) {
+	cases := []struct {
+		name, in, exp string
+	}{
+		{"backslash", "Foo\\Bar", "Foo\\\\Bar"},
+		{"carriageReturn", "Foo\rBar", "Foo\\0DBar"},
+		{"comma", "Foo,Bar", "Foo\\,Bar"},
+		{"default", "MicroMDM", "MicroMDM"},
+		{"doubleQuote", "\"Foo\"Bar", "\\\"Foo\\\"Bar"},
+		{"emptyString", "", ""},
+		{"equalsSign", "Foo=Bar", "Foo\\=Bar"},
+		{"forwardsSlash", "Foo/Bar", "Foo\\/Bar"},
+		{"hashAtStart", "#Foo", "\\#Foo"},
+		{"leftAngleBracket", "Foo<Bar", "Foo\\<Bar"},
+		{"lineFeed", "Foo\nBar", "Foo\\0ABar"},
+		{"plusSign", "Foo+Bar", "Foo\\+Bar"},
+		{"rightAngleBracket", "Foo>Bar", "Foo\\>Bar"},
+		{"semicolon", "Foo;Bar", "Foo\\;Bar"},
+		{"spaceAtEnd", "Foo ", "Foo\\ "},
+		{"spaceAtStart", " Foo", "\\ Foo"},
+		{"spaceAtStartAndEnd", " Foo ", "\\ Foo\\ "},
+		{"spaceOnly", " ", "\\ "},
+		{"null", "Foo\x00Bar", "Foo\\00Bar"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := escapeAttributeValue(c.in)
+
+			if got != c.exp {
+				t.Errorf("Got %s; want %s", got, c.exp)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/boltdb/bolt"
@@ -348,7 +349,7 @@ func (c *Server) setupSCEP(logger log.Logger) error {
 		return err
 	}
 
-	_, err = depot.CreateOrLoadCA(key, 5, "MicroMDM", "US")
+	_, err = depot.CreateOrLoadCA(key, 5, c.SCEPOrg, strings.ToUpper(c.SCEPOrg)+" SCEP CA", "US")
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	SCEPChallenge          string
 	SCEPClientValidity     int
 	TLSCertPath            string
+	SCEPOrg                string
 	SCEPDepot              *boltdepot.Depot
 	UseDynSCEPChallenge    bool
 	GenDynSCEPChallenge    bool
@@ -244,10 +245,7 @@ func (c *Server) setupPushService(logger log.Logger) error {
 }
 
 func (c *Server) setupEnrollmentService() error {
-	var (
-		SCEPCertificateSubject string
-		err                    error
-	)
+	var err error
 
 	chalStore := c.SCEPChallengeDepot
 	if !c.GenDynSCEPChallenge {
@@ -263,7 +261,7 @@ func (c *Server) setupEnrollmentService() error {
 		c.SCEPChallenge,
 		c.ServerPublicURL,
 		c.TLSCertPath,
-		SCEPCertificateSubject,
+		c.SCEPOrg,
 		c.ProfileDB,
 		chalStore,
 	)


### PR DESCRIPTION
Allow us to set the organization referenced in various configuration
profile via a command-line flag or environment variable.

This commit also removes the ability to set the SCEP Subject via an
argument in service.NewService. The only caller of this function never
set it to anything other than empty string, causing the default to be
used, so it was redundant.